### PR TITLE
Update jqcloud.js

### DIFF
--- a/src/jqcloud.js
+++ b/src/jqcloud.js
@@ -336,8 +336,8 @@
       this.$element.append(word_span);
 
       word_size = {
-        width: word_span.width(),
-        height: word_span.height()
+        width: word_span.outerWidth(),
+        height: word_span.outerHeight()
       };
       word_size.left = this.options.center.x*this.options.width - word_size.width / 2.0;
       word_size.top = this.options.center.y*this.options.height - word_size.height / 2.0;


### PR DESCRIPTION
Let us use the outerWidth and outerHeight of the word span to avoid overlaps.